### PR TITLE
Remove class alias maps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,11 +55,6 @@
     }
   },
   "extra": {
-    "typo3/class-alias-loader": {
-        "class-alias-maps": [
-          "Migrations/Code/ClassAliasMap.php"
-        ]
-    },
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web"


### PR DESCRIPTION
Since the class alias maps were deleted, this causes composer to throw a warning while updating the extension packages.